### PR TITLE
ci: enforce conventional commits on PR titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,20 @@
 <!--
 Thanks for contributing to awesome-trading-agents.
+
+PR title MUST follow Conventional Commits (CI-enforced):
+  <type>(<scope>): <subject>
+Examples:
+  docs(agents): add foo/bar to benchmarks
+  fix(mcp): remove archived baz-server
+  style(zh-CN): add CJK spacing in some entry
+See CONTRIBUTING.md §9 for the full spec.
+
 Please fill out the fields below. See CONTRIBUTING.md for the full
 quality bar, submission format, and bilingual-PR rule.
-感谢贡献。请按下列模板填写。中文规则见 CONTRIBUTING.zh-CN.md。
+
+感谢贡献。请按下列模板填写。
+PR 标题必须遵循 Conventional Commits（CI 强制校验），详见 CONTRIBUTING.zh-CN.md §9。
+其余规则见 CONTRIBUTING.zh-CN.md。
 -->
 
 ## 1. Repo URL · 仓库链接

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,60 @@
+name: PR Title Check
+
+# Validates PR titles against Conventional Commits.
+#
+# Why: this repo squash-merges every PR, so the PR title becomes the
+# subject of the resulting commit on `master`. Individual commits on a
+# PR branch are not constrained — only the PR title is.
+#
+# Spec: see CONTRIBUTING.md §9 / CONTRIBUTING.zh-CN.md §9.
+#
+# Allowed types:
+#   docs · fix · style · chore · ci · refactor · feat
+#
+# Allowed scopes (optional — small PRs may omit a scope):
+#   agents · mcp · skills · papers · en · zh-CN · ci · infra
+#
+# Subject rules (enforced via `subjectPattern`):
+#   - Must start with a lowercase letter (imperative mood, no caps).
+#   - Must not end with a period.
+#   - Should fit within ~72 characters (GitHub UI truncation point).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            docs
+            fix
+            style
+            chore
+            ci
+            refactor
+            feat
+          scopes: |
+            agents
+            mcp
+            skills
+            papers
+            en
+            zh-CN
+            ci
+            infra
+          requireScope: false
+          subjectPattern: ^[a-z].+[^.]$
+          subjectPatternError: |
+            The subject "{subject}" doesn't match the required pattern.
+            It must start with a lowercase letter and must not end with
+            a period. See CONTRIBUTING.md §9 for the full spec.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,56 @@ malformed links, accidental duplicate primary entries, misspellings, or rows
 that no longer match the local entry format. Do not reformat the whole README
 only to silence low-signal lint noise.
 
-## 9. Code of conduct
+## 9. PR title & commit conventions
+
+This repo follows [Conventional Commits](https://www.conventionalcommits.org/).
+Because we **squash-merge** every PR, the **PR title becomes the subject of the
+resulting commit on `master`** — so the PR title is the only thing that needs
+to follow the format. Individual commits on a PR branch are unconstrained.
+
+A GitHub Action (`.github/workflows/pr-title.yml`) validates every PR title
+against the spec below. PRs whose title doesn't match cannot be merged.
+
+### Format
+
+```
+<type>(<scope>): <subject>
+```
+
+### Types
+
+| type       | when to use                                                    |
+|------------|----------------------------------------------------------------|
+| `docs`     | add / remove / edit list entries, README content               |
+| `fix`      | dead link, typo, broken or misclassified entry                 |
+| `style`    | formatting, CJK whitespace, pure layout                        |
+| `chore`    | repo maintenance, dependency bumps                             |
+| `ci`       | workflows, lint config, `.lycheeignore`                        |
+| `refactor` | restructure or move existing entries / categories              |
+| `feat`     | new section, new pillar, larger structural addition            |
+
+### Scopes (optional)
+
+`agents` · `mcp` · `skills` · `papers` · `en` · `zh-CN` · `ci` · `infra`
+
+Small PRs may omit a scope (e.g. `fix: typo in intro`).
+
+### Subject
+
+- Imperative mood, lowercase first word (`add`, not `Added` or `Adds`).
+- No trailing period.
+- Fit within ~72 characters (GitHub UI truncates beyond this).
+- English by default; Chinese acceptable for `zh-CN`-scoped changes.
+
+### Examples
+
+- `docs(agents): add HKUSTDial/DeepFund to benchmarks`
+- `fix(mcp): remove archived foo-server entry`
+- `style(zh-CN): add CJK spacing in DeepEar entry`
+- `ci: ignore github topic pages in lychee`
+- `chore: bump label set to v1.1`
+
+## 10. Code of conduct
 
 This project follows the
 [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
@@ -188,7 +237,7 @@ Please keep discussions respectful, assume good faith, and focus on the
 technical and curation work. Maintainers may close threads that become personal,
 repetitive, or unrelated to improving the list.
 
-## 10. License notice
+## 11. License notice
 
 The list text, curation structure, README files, contribution guides, and PR
 text contributed to this repository are released under [CC0-1.0](LICENSE). By

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -157,14 +157,63 @@ npx --yes awesome-lint README.zh-CN.md
 如果 PR 新引入了高信号问题，应当修复：Markdown 损坏、链接格式错误、意外重复主条目、
 拼写问题、条目不符合本仓库格式等。不要为了消除低信号 lint 噪音而大规模重排 README。
 
-## 9. 行为准则
+## 9. PR 标题与 commit 约定
+
+本仓库遵循 [Conventional Commits](https://www.conventionalcommits.org/)。
+由于我们对所有 PR 使用 **squash-merge**，**PR 标题就是 master 上 squash
+commit 的 subject**——所以只需要约束 PR 标题；PR 分支内部的细节 commit
+不受约束。
+
+`.github/workflows/pr-title.yml` 会自动校验每个 PR 标题。不符合规范的 PR
+无法合并。
+
+### 格式
+
+```
+<type>(<scope>): <subject>
+```
+
+### Types
+
+| type       | 适用场景                                              |
+|------------|-------------------------------------------------------|
+| `docs`     | 增删改清单条目、README 内容                           |
+| `fix`      | 死链、错别字、错误条目                                |
+| `style`    | 排版、中英文空格、纯格式                              |
+| `chore`    | 仓库维护、依赖升级                                    |
+| `ci`       | workflows、lint 配置、`.lycheeignore`                 |
+| `refactor` | 调整或移动现有条目 / 分类                             |
+| `feat`     | 新章节、新支柱、较大结构性添加                        |
+
+### Scopes（可选）
+
+`agents` · `mcp` · `skills` · `papers` · `en` · `zh-CN` · `ci` · `infra`
+
+小型 PR 可不带 scope（例：`fix: typo in intro`）。
+
+### Subject
+
+- 祈使句首词小写（`add`，不是 `Added` / `Adds`）。
+- 末尾不加句号。
+- 控制在 ~72 字符以内（GitHub UI 截断阈值）。
+- 默认英文；scope 为 `zh-CN` 的纯中文修改可使用中文。
+
+### 示例
+
+- `docs(agents): add HKUSTDial/DeepFund to benchmarks`
+- `fix(mcp): remove archived foo-server entry`
+- `style(zh-CN): add CJK spacing in DeepEar entry`
+- `ci: ignore github topic pages in lychee`
+- `chore: bump label set to v1.1`
+
+## 10. 行为准则
 
 本项目遵循
 [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)。
 讨论时请保持尊重、善意推断，尽量聚焦技术和策展问题。若讨论变成人身化、重复拉扯，
 或偏离如何改进清单，维护者可能会关闭相关 thread。
 
-## 10. 许可证说明
+## 11. 许可证说明
 
 本清单文本、策展结构、README、贡献指南，以及贡献者提交到本仓库的 PR 文本，均以
 [CC0-1.0](LICENSE) 发布。提交 PR 即表示你同意你对清单文本的贡献以 CC0-1.0 发布。


### PR DESCRIPTION
## Summary

Squash-merge makes the PR title the subject of the resulting commit on `master`,
so we now validate PR titles against [Conventional Commits](https://www.conventionalcommits.org/)
on every open / edit / sync.

## Changes

- `.github/workflows/pr-title.yml` — new workflow using
  [`amannn/action-semantic-pull-request@v5`](https://github.com/amannn/action-semantic-pull-request).
- `CONTRIBUTING.md` and `CONTRIBUTING.zh-CN.md` — new section 9 "PR title &
  commit conventions" documenting the spec; old sections 9-10 renumbered to 10-11.
- `.github/PULL_REQUEST_TEMPLATE.md` — top comment now leads with the title spec
  so contributors see it before they file.

## Spec at a glance

```
<type>(<scope>): <subject>
```

- **Types**: `docs`, `fix`, `style`, `chore`, `ci`, `refactor`, `feat`
- **Scopes (optional)**: `agents`, `mcp`, `skills`, `papers`, `en`, `zh-CN`,
  `ci`, `infra`
- **Subject**: imperative mood, lowercase first word, no trailing period, ≤ 72 chars

## This PR self-validates

The new workflow runs on this PR. Title `ci: enforce conventional commits on PR titles`
matches the spec (`type=ci`, no scope, lowercase subject, no period, 47 chars).

## Follow-up

- Add `Validate PR title (Conventional Commits)` to the master branch ruleset's
  required status checks once this lands.
