### PR TITLE
fix(infra): tighten stars line in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -53,7 +53,7 @@ stars in the quality-bar metadata instead.
 
 <!-- Tick each box that applies. See CONTRIBUTING.md §2 / CONTRIBUTING.zh-CN.md §2 for full criteria. -->
 
-- **GitHub stars at submission time**: <!-- e.g. 1.2k; repo entries normally need >=100 stars for the main list -->
+**GitHub stars at submission time**: <!-- e.g. 1.2k; repo entries normally need >=100 stars for the main list -->
 
 - [ ] **Open source** — or has a public technical artifact
       (paper, architecture doc, reproducible demo).


### PR DESCRIPTION
> **PR type**: infra fix — sections 1-4 of the entry template do not apply.

## 1. Repo URL · 仓库链接

N/A — modifies `.github/PULL_REQUEST_TEMPLATE.md` only.

## 2. Pillar + sub-category · 放在哪个分类

N/A — infra fix.

## 3. Entry bullet · 条目

N/A — no entry added.

## 4. Quality-bar self-checklist · 条目自查

N/A — no entry to evaluate.

## 5. Bilingual symmetric-edit · 中英文同步

- [x] N/A — the PR template is a single bilingual file with no `zh-CN` sibling.

## 6. Awesome-lint advisory check · awesome-lint 辅助检查

- [x] N/A — README files are not modified.

## 7. Curation notes (optional) · 补充说明（可选）

Fixes a CommonMark **loose-list rendering bug** in `.github/PULL_REQUEST_TEMPLATE.md` §4.

### What was wrong

The template had `**GitHub stars at submission time**` as the **first bullet** of the quality-bar list, followed by a blank line, then the six checkbox bullets:

```markdown
- **GitHub stars at submission time**: <!-- ... -->

- [ ] **Open source** — ...
- [ ] **Demonstrably LLM-driven** — ...
...
```

Per the [CommonMark spec on loose lists](https://spec.commonmark.org/0.30/#lists), **any blank line inside a list turns the entire list loose** — GitHub then wraps every `<li>` in a `<p>` with `margin-bottom: 16px`, producing a giant vertical gap between every checkbox row. We hit this in #1 (rendered DeepFund PR body) and #5 (this same template body).

### The fix

Drop the leading `- ` from the stars line so it becomes a **paragraph above the list** instead of the first list item:

```markdown
**GitHub stars at submission time**: <!-- ... -->

- [ ] **Open source** — ...
- [ ] **Demonstrably LLM-driven** — ...
...
```

Visually identical at the top (paragraph still sits above the bullets), but the list is now tight and renders with normal row spacing.

### Scope check

- `.github/ISSUE_TEMPLATE/add-entry.md` separates `GitHub stars` (§4) and the checklist (§5) into different `##` sections — no loose-list issue, no change needed.
- `.github/ISSUE_TEMPLATE/remove-entry.md` and `restructure.md` have no stars/checklist combo — no change needed.

## 8. Extra notes · 额外说明

- One-line diff in a single file; pure rendering fix.
- PR #5's body still uses the broken pattern; will edit it after this lands so the template fix is in master first.
