### PR TITLE
Add The Stall — x402 pay-per-call capability chassis (US stocks, risk scoring, market intel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ MCPs are servers that let an agent call external tools through the Model Context
 - [financial-datasets/mcp-server](https://github.com/financial-datasets/mcp-server) - Financial Datasets' first-party MCP; US-equity + crypto fundamentals (3 statements + ratios) + prices + news.
 - [6551Team/opennews-mcp](https://github.com/6551Team/opennews-mcp) - 84+ news-source aggregation (Bloomberg / Reuters / FT / CoinDesk and more) + AI impact-scoring / trading-signal + WebSocket streaming.
 - [BlockRunAI/blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) - Real-time data MCP with pay-per-call x402 payments; covers search, research, quotes, crypto, X, and Twitter.
+- [The Stall](https://github.com/thebrierfox/the-stall) - Pay-per-call x402 capability chassis for AI agents on Base mainnet. US stock prices (NYSE/NASDAQ via Yahoo Finance, $0.030/call), concentration-risk scoring for x402 wallets (HHI-based, $0.10/call), and settlement-verified market intelligence sourced from on-chain USDC settlements ($0.50/call). No API keys required. Live: https://the-stall.intuitek.ai
 <a id="mcps-financemcp"></a>
 - [guangxiangdebizi/FinanceMCP](https://github.com/guangxiangdebizi/FinanceMCP) - Tushare + Binance MCP spanning A-shares / HK / US / funds / bonds / macro / stablecoins / crypto / financial news.
 - [saidsurucu/borsa-mcp](https://github.com/saidsurucu/borsa-mcp) - Turkish BIST + US-equity + fund data MCP serving regional markets outside China and the US.


### PR DESCRIPTION
**The Stall** is a live x402 pay-per-call MCP server running on Base mainnet at https://the-stall.intuitek.ai

Added to the **Market data / data providers** section, immediately after BlockRunAI (the existing x402 pay-per-call entry).

| Capability | Price | Source |
|---|---|---|
| US stock price (NYSE/NASDAQ) | $0.030/call | Yahoo Finance public API |
| Concentration-risk score (HHI) | $0.10/call | On-chain settlement archive |
| Settlement-verified market intelligence | $0.50/call | Base mainnet EIP-3009 events |

- **GitHub:** https://github.com/thebrierfox/the-stall
- **Live endpoint:** https://the-stall.intuitek.ai
- **Network:** Base mainnet (USDC)
- **Protocol:** x402-express — agents pay per call with no API keys, no accounts, no middleware required on the caller side.

Directly comparable to BlockRunAI but focused on equities data and on-chain intelligence rather than crypto/X/news.