### PR TITLE
Add BDE Score™ MCP to Research tools / analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ MCPs are servers that let an agent call external tools through the Model Context
 - [guangxiangdebizi/TradingAgents-MCPmode](https://github.com/guangxiangdebizi/TradingAgents-MCPmode) - TradingAgents refactored as MCP tools for multi-agent equity research.
 - [QuantMLResearch/AI-Kline](https://github.com/QuantMLResearch/AI-Kline) - Stock-analysis tool combining classic technical analysis, AI prediction, and MCP access.
 - [wbsu2003/stock-scanner-mcp](https://github.com/wbsu2003/stock-scanner-mcp) - Stock scanner MCP for prices, scoring, technical reports, and AI summaries.
+- [hbhqq9/bde-score](https://github.com/hbhqq9/bde-score) - Multi-market (US/HK/A-share) stock scoring MCP with x402 micropayments; 5-factor BDE Score (0–100), EU AI Act Art.50 compliant, 73 stocks across 3 markets.
 
 > Also relevant: [dragon1086/prism-insight](#agents-prism-insight) is listed under Agents; this section mentions it because it has built-in MCP support for research.
 


### PR DESCRIPTION
## BDE Score™ - Multi-market Stock Scoring MCP Server

Adding BDE Score to the MCPs → Research tools / analysis section.

**What it does:**
- Multi-factor stock analysis (US/HK/A-share) via MCP protocol
- 5-factor scoring system (Momentum, Mean Reversion, Volume, Volatility, Trend)
- 73 stocks across 3 markets with comparable scoring
- x402 micropayment support ($0.01/query in USDC on Base)
- EU AI Act Art.50 compliant with explainable methodology

**Why it fits:**
BDE Score is a stock-analysis MCP tool for AI agents, alongside existing entries like stock-scanner-mcp and maverick-mcp.

GitHub: https://github.com/hbhqq9/bde-score