### PR TITLE
Add: My AI Investment OS — free AI investing diagnostic + 6 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ Skills are reusable instructions and workflows for Claude Code or other agent sy
 <a id="resources"></a>
 ## Resources
 
+- [My AI Investment OS](https://ordinarymantrying.com/tools/ai-invest-os.html) - Free 5-question diagnostic identifying your investing school (Index/Value/Growth/Trend) with 8-AI committee verdict and personalized Prompt Library. Includes 6 companion tools: DCA Simulator, Recovery Navigator, Dividend Engine, Kelly Master, Pyramid Builder, Portfolio Clarity. No login required.
+
 <a id="resources-papers"></a>
 ### Papers
 


### PR DESCRIPTION
Hi! Adding a free AI investing diagnostic tool that fits this list.

**[My AI Investment OS](https://ordinarymantrying.com/tools/ai-invest-os.html)**

Built after 7 experiments with 8 AI models — every model converged on 4 investing schools. Free 5-question diagnostic + 6 companion tools. No login required.