### PR TITLE
Update Equibles entry to the hosted MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ MCPs are servers that let an agent call external tools through the Model Context
 - [imbenrabi/Financial-Modeling-Prep-MCP-Server](https://github.com/imbenrabi/Financial-Modeling-Prep-MCP-Server) - FMP MCP with 250+ tools for fundamentals, market intelligence, and ETFs.
 - [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) - Minimal yfinance MCP; a lightweight Yahoo Finance data option.
 - [OctagonAI/octagon-mcp-server](https://github.com/OctagonAI/octagon-mcp-server) - MCP for filings, earnings calls, financials, stock data, private-market deals, and web research.
-- [daniel3303/Equibles](https://github.com/daniel3303/Equibles) - Self-hosted finance data hub; syncs public SEC/FRED/Yahoo/FINRA/CFTC/CBOE data to PostgreSQL and serves it via MCP.
+- [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server) - Equibles; US stock market data over MCP - live stock and options prices, congressional trades, insider transactions, SEC filings full-text search, XBRL fundamentals, 13F holdings, earnings-call transcripts, short interest and FRED macro. 90+ tools; hosted at https://mcp.equibles.com/mcp or self-hosted.
 
 <a id="mcps-brokerage"></a>
 ### Brokerage / exchange trading

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -209,7 +209,7 @@ MCPs 是让 Agent 通过 Model Context Protocol 调用外部工具的服务。�
 - [imbenrabi/Financial-Modeling-Prep-MCP-Server](https://github.com/imbenrabi/Financial-Modeling-Prep-MCP-Server) - FMP MCP，提供 250+ 工具，覆盖基本面、市场洞察和 ETF。
 - [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) - 极简 yfinance MCP；获取 Yahoo Finance 数据的轻量选择。
 - [OctagonAI/octagon-mcp-server](https://github.com/OctagonAI/octagon-mcp-server) - 文件 / 财报会议 / 财务 / 股票数据 / 私募交易 / 网络研究；覆盖私募市场交易与 VC 数据。
-- [daniel3303/Equibles](https://github.com/daniel3303/Equibles) - 自部署金融数据中转站；把 SEC / FRED / Yahoo / FINRA / CFTC / CBOE 数据同步到 PostgreSQL，再通过 MCP 给 Agent 查询。
+- [daniel3303/stock-market-mcp-server](https://github.com/daniel3303/stock-market-mcp-server) - Equibles；美股市场数据 MCP —— 实时股票与期权价格、美国国会议员交易、内部人交易、SEC 文件全文检索、XBRL 基本面、13F 机构持仓、财报电话会议记录、做空数据与 FRED 宏观数据，共 90+ 个工具；远程服务 https://mcp.equibles.com/mcp，亦可自部署。
 
 <a id="mcps-brokerage"></a>
 ### Brokerage / exchange trading


### PR DESCRIPTION
The existing entry points at the self-host repo and undersells what the server does.

Equibles runs as a hosted remote MCP server at `https://mcp.equibles.com/mcp` (free API key or OAuth) with 90+ tools: live stock and options prices, congressional trades, insider transactions, SEC filings full-text search, XBRL fundamentals, 13F institutional holdings, earnings-call transcripts, short interest, and FRED macro series. Self-hosting is still supported.

Updated both the English and Chinese lists to point at the documented server repo.