### PR TITLE
docs(mcps): add DepthFeed prediction-market data MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ MCPs are servers that let an agent call external tools through the Model Context
 <a id="mcps-prediction-market"></a>
 ### Prediction markets
 
+<a id="mcps-depthfeed"></a>
+- [vcorp-dev/depthfeed-mcp](https://github.com/vcorp-dev/depthfeed-mcp) - First-party prediction-market data MCP with live and historical order books across Polymarket, Kalshi, and Limitless.
 <a id="mcps-polymarket"></a>
 - [caiovicentino/polymarket-mcp-server](https://github.com/caiovicentino/polymarket-mcp-server) - 45-tool Polymarket MCP; real-time monitoring and explicit order-safety guards.
 <a id="mcps-polymarket-paper-trader"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -249,6 +249,8 @@ MCPs 是让 Agent 通过 Model Context Protocol 调用外部工具的服务。�
 <a id="mcps-prediction-market"></a>
 ### Prediction markets
 
+<a id="mcps-depthfeed"></a>
+- [vcorp-dev/depthfeed-mcp](https://github.com/vcorp-dev/depthfeed-mcp) - DepthFeed 官方预测市场数据 MCP；提供 Polymarket、Kalshi 与 Limitless 的实时及历史订单簿。
 <a id="mcps-polymarket"></a>
 - [caiovicentino/polymarket-mcp-server](https://github.com/caiovicentino/polymarket-mcp-server) - 45 工具 Polymarket MCP；实时监控 + 显式下单安全保护。
 <a id="mcps-polymarket-paper-trader"></a>


### PR DESCRIPTION
## Summary

Add DepthFeed's first-party MCP server to **MCPs → Prediction markets** in both the English and Simplified Chinese READMEs.

The public remote MCP exposes read-only live and historical order-book tools for Polymarket, Kalshi, and Limitless. It is keyless to start and is directly usable from MCP-capable agent clients.

## Submission metadata

- Repository: https://github.com/vcorp-dev/depthfeed-mcp
- Pillar/sub-category: MCPs → Prediction markets
- GitHub stars at submission: 1
- Most recent repository activity at submission: 2026-07-26
- Public product documentation: https://depthfeed.com/mcp

## Quality-bar self-evaluation

- [x] **Public technical artifact:** the first-party MCP integration repository is public, documented, and points to a live remote MCP endpoint.
- [x] **Demonstrably agent-driven:** its purpose is to expose prediction-market data as MCP tools to Claude, Cursor, Codex, ChatGPT, and other MCP clients.
- [x] **Recently active:** updated within the last 12 months.
- [x] **Clear scope and documentation:** the repository and product documentation describe setup, transport, authentication, and tools.
- [x] **Distinct contribution:** the nearby entries focus on Polymarket monitoring or paper trading; DepthFeed provides multi-venue historical and live order-book data.
- [x] **Credibility exception:** although the repository is below the default 100-star floor, it is the first-party artifact of the listed data vendor, which the guide explicitly permits as an exception.

## Verification

- `npx --yes awesome-lint README.md`
- `npx --yes awesome-lint README.zh-CN.md`

Both checks pass.

## Disclosure

I am affiliated with DepthFeed and am submitting this first-party listing for maintainer review.
