### PR TITLE
docs(mcp): add Bitget-AI/agent-mcp to brokerage MCPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ MCPs are servers that let an agent call external tools through the Model Context
 <a id="mcps-koreainvestment"></a>
 - [koreainvestment/open-trading-api](https://github.com/koreainvestment/open-trading-api) - Korea Investment & Securities official SDK; includes a Trading MCP, strategy builder, and backtester.
 - [okx/agent-trade-kit](https://github.com/okx/agent-trade-kit) - OKX official MCP for spot, perpetuals, futures, options, and grid bots.
+- [Bitget-AI/agent-mcp](https://github.com/Bitget-AI/agent-mcp) - Bitget's official MCP for spot & futures trading; 89 UTA v3 operations via 14 tools, HMAC-signed, with paper-trading mode.
 - [ariadng/metatrader-mcp-server](https://github.com/ariadng/metatrader-mcp-server) - Representative MT5 MCP; lets LLMs trade through any MetaTrader 5 broker; MCP connector for a major retail-forex platform.
 - [Qoyyuum/mcp-metatrader5-server](https://github.com/Qoyyuum/mcp-metatrader5-server) - Alternative MT5 MCP for quotes, trading, and history; uses MCP resources as well as tools.
 - [rcontesti/IB_MCP](https://github.com/rcontesti/IB_MCP) - Representative IBKR MCP; exposes Interactive Brokers TWS / Gateway as MCP tools; aimed at professional-broker workflows.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -221,6 +221,7 @@ MCPs 是让 Agent 通过 Model Context Protocol 调用外部工具的服务。�
 <a id="mcps-koreainvestment"></a>
 - [koreainvestment/open-trading-api](https://github.com/koreainvestment/open-trading-api) - 韩国投资证券 KIS 官方 SDK；包含 Trading MCP、strategy builder 和 backtester。
 - [okx/agent-trade-kit](https://github.com/okx/agent-trade-kit) - OKX 官方 MCP；覆盖现货、永续、期货、期权和网格机器人。
+- [Bitget-AI/agent-mcp](https://github.com/Bitget-AI/agent-mcp) - Bitget 官方 MCP，支持现货与合约交易；14 个工具封装 89 个 UTA v3 操作，本地 HMAC 签名，并提供 paper-trading 模式。
 - [ariadng/metatrader-mcp-server](https://github.com/ariadng/metatrader-mcp-server) - MT5 MCP；让 LLM 通过任意 MetaTrader 5 经纪商交易；面向主流零售外汇平台的 MCP 连接器。
 - [Qoyyuum/mcp-metatrader5-server](https://github.com/Qoyyuum/mcp-metatrader5-server) - 另一个 MT5 MCP；提供行情、交易和历史数据，并同时使用 MCP resources 与 tools。
 - [rcontesti/IB_MCP](https://github.com/rcontesti/IB_MCP) - IBKR MCP；把 Interactive Brokers TWS / Gateway 暴露为 MCP 工具；面向专业经纪商场景。


### PR DESCRIPTION
## 1. Repo URL · 仓库链接
https://github.com/Bitget-AI/agent-mcp

## 2. Pillar + sub-category · 放在哪个分类
MCPs > Brokerage / exchange trading

## 3. Entry bullet · 条目

```markdown
- [Bitget-AI/agent-mcp](https://github.com/Bitget-AI/agent-mcp) - Bitget's official MCP for spot & futures trading; 89 UTA v3 operations via 14 tools, HMAC-signed, with paper-trading mode.

## 4. Quality-bar self-checklist · 条目自查

GitHub stars at submission time: 0

- [x] Open source — or has a public technical artifact
- [x] Demonstrably LLM-driven — LLM reasoning is a primary decision component
- [x] Active in last 12 months
- [x] Clear scope + minimal documentation
- [x] Distinct contribution — not duplicative of existing entries
- [ ] Public credibility signal — normally >=100 GitHub stars for repo entries, or a documented maintainer-level exception

If any box is unchecked, briefly justify the waiver:
First-party official MCP server from Bitget, a recognized cryptocurrency exchange — this is the documented first-party exception to the 100-star floor described in CONTRIBUTING.md section 2.

## 5. Bilingual symmetric-edit · 中英文同步

- [x] I edited both README.md and README.zh-CN.md in this PR.

## 6. Awesome-lint advisory check · awesome-lint 辅助检查

- [ ] I ran npx --yes awesome-lint README.md
- [ ] I ran npx --yes awesome-lint README.zh-CN.md
- Notes: single-line entry addition, no structural change to either file.