### PR TITLE
docs(mcp): add Bitget-AI/agent-cli and Bitget-AI/agent-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ MCPs are servers that let an agent call external tools through the Model Context
 - [alpacahq/alpaca-mcp-server](https://github.com/alpacahq/alpaca-mcp-server) - Alpaca's official MCP for market data plus paper or live trading in equities, ETFs, options, and crypto. *(← used by: [tradermonty/claude-trading-skills](#skills-claude-trading-skills), [staskh/trading_skills](#skills-trading-skills), [huygiatrng/AlpacaTradingAgent](#agents-tradingagents).)*
 <a id="mcps-kraken-cli"></a>
 - [krakenfx/kraken-cli](https://github.com/krakenfx/kraken-cli) - Kraken's official AI-native CLI with an embedded MCP; covers crypto, xStocks, forex, derivatives, paper trading, and bundled SKILL.md packs.
+- [Bitget-AI/agent-cli](https://github.com/Bitget-AI/agent-cli) - Bitget's official terminal AI trading tool (`bgc`) wrapping the Bitget UTA v3 API across market, trade, account, funds, subaccount, loan, and tax domains, with dry-run, read-only, confirm, and paper-trading safety flags.
 <a id="mcps-koreainvestment"></a>
 - [koreainvestment/open-trading-api](https://github.com/koreainvestment/open-trading-api) - Korea Investment & Securities official SDK; includes a Trading MCP, strategy builder, and backtester.
 - [okx/agent-trade-kit](https://github.com/okx/agent-trade-kit) - OKX official MCP for spot, perpetuals, futures, options, and grid bots.
@@ -294,6 +295,7 @@ Skills are reusable instructions and workflows for Claude Code or other agent sy
 - [okx/agent-skills](https://github.com/okx/agent-skills) - OKX bilingual Skills repo with contribution, review, and security guidance; companion to onchainos-skills.
 - [GMGNAI/gmgn-skills](https://github.com/GMGNAI/gmgn-skills) - GMGN Agent Skills for querying tokens, wallets, and market data, and executing on-chain trades across Solana, BSC, and Base.
 - [Polymarket/agent-skills](https://github.com/Polymarket/agent-skills) - First-party Polymarket Agent Skill for auth, orders, market data, WebSockets, bridging, and gasless flows.
+- [Bitget-AI/agent-skill](https://github.com/Bitget-AI/agent-skill) - Bitget's official AI trading skill file giving Claude Code, Codex, and OpenClaw the judgment to invoke `bgc` (Bitget-AI/agent-cli) safely, shipped as pure Markdown with no runtime or API key required.
 
 <a id="skills-strategy-coding"></a>
 ### Strategy coding & backtesting

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -218,6 +218,7 @@ MCPs 是让 Agent 通过 Model Context Protocol 调用外部工具的服务。�
 - [alpacahq/alpaca-mcp-server](https://github.com/alpacahq/alpaca-mcp-server) - Alpaca 官方 MCP；提供行情，并支持股票、ETF、期权和加密的纸面或实盘交易。 *(← used by: [tradermonty/claude-trading-skills](#skills-claude-trading-skills), [staskh/trading_skills](#skills-trading-skills), [huygiatrng/AlpacaTradingAgent](#agents-tradingagents).)*
 <a id="mcps-kraken-cli"></a>
 - [krakenfx/kraken-cli](https://github.com/krakenfx/kraken-cli) - Kraken 官方 AI-native CLI，内置 MCP；覆盖加密、xStocks、外汇、衍生品、纸面交易，并附带 SKILL.md packages。
+- [Bitget-AI/agent-cli](https://github.com/Bitget-AI/agent-cli) - Bitget 官方终端 AI 交易工具（`bgc`），封装 Bitget UTA v3 API，覆盖市场、交易、账户、资金、子账户、借贷、税务等领域，内置dry-run、只读、二次确认、模拟盘等安全开关。
 <a id="mcps-koreainvestment"></a>
 - [koreainvestment/open-trading-api](https://github.com/koreainvestment/open-trading-api) - 韩国投资证券 KIS 官方 SDK；包含 Trading MCP、strategy builder 和 backtester。
 - [okx/agent-trade-kit](https://github.com/okx/agent-trade-kit) - OKX 官方 MCP；覆盖现货、永续、期货、期权和网格机器人。
@@ -291,6 +292,7 @@ Skills 是给 Claude Code 或其他 Agent 系统复用的说明和工作流。�
 - [okx/agent-skills](https://github.com/okx/agent-skills) - OKX 双语 EN / CN Skills 仓库；包含贡献、评审和安全说明；可和 onchainos-skills 一起看。
 - [GMGNAI/gmgn-skills](https://github.com/GMGNAI/gmgn-skills) - GMGN Agent Skills；查询 token、钱包和行情数据，并在 Solana / BSC / Base 上执行链上交易。
 - [Polymarket/agent-skills](https://github.com/Polymarket/agent-skills) - Polymarket 官方 Agent Skill；覆盖认证、下单、行情、WebSocket、桥接和 gasless 交易流程。
+- [Bitget-AI/agent-skill](https://github.com/Bitget-AI/agent-skill) - Bitget 官方 AI 交易技能文件，让 Claude Code、Codex、OpenClaw 具备判断何时调用 `bgc`（Bitget-AI/agent-cli）的能力，纯 Markdown 实现，无需运行时或 API 密钥。
 
 <a id="skills-strategy-coding"></a>
 ### Strategy coding & backtesting


### PR DESCRIPTION
**Repo URL(s):**
- https://github.com/Bitget-AI/agent-cli
- https://github.com/Bitget-AI/agent-skill

**Pillar & category:**
- MCPs > Brokerage / exchange trading (agent-cli)
- Skills > Crypto / DeFi / on-chain (agent-skill)

**Entry bullet(s):**
- [Bitget-AI/agent-cli](https://github.com/Bitget-AI/agent-cli) - Bitget's official terminal AI trading tool (`bgc`) wrapping the Bitget UTA v3 API across market, trade, account, funds, subaccount, loan, and tax domains, with dry-run, read-only, confirm, and paper-trading safety flags.
- [Bitget-AI/agent-skill](https://github.com/Bitget-AI/agent-skill) - Bitget's official AI trading skill file giving Claude Code, Codex, and OpenClaw the judgment to invoke `bgc` (Bitget-AI/agent-cli) safely, shipped as pure Markdown with no runtime or API key required.

**Submission checklist:**
- [x] Entries placed in the most specific existing category
- [x] Description is a single sentence ending with punctuation
- [x] Links are not already listed elsewhere in the README
- [x] Both repos are official Bitget-AI first-party projects (exchange-official exception to the 100-star floor)

**Bilingual symmetric edit:**
- [x] README.md and README.zh-CN.md updated in the same position, same order, same commit

**Self-evaluation against quality bar:**
Both repos are official, first-party Bitget tooling that fill a gap in the existing Brokerage/Skills sections — agent-cli is a dedicated terminal trading tool (distinct from the existing Bitget-AI/agent_hub-style MCP servers), and agent-skill is the companion skill file that teaches an agent when to invoke it safely.