### PR TITLE
docs(mcp): add Bargo Congress MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ MCPs are servers that let an agent call external tools through the Model Context
 - [financial-datasets/mcp-server](https://github.com/financial-datasets/mcp-server) - Financial Datasets' first-party MCP; US-equity + crypto fundamentals (3 statements + ratios) + prices + news.
 - [6551Team/opennews-mcp](https://github.com/6551Team/opennews-mcp) - 84+ news-source aggregation (Bloomberg / Reuters / FT / CoinDesk and more) + AI impact-scoring / trading-signal + WebSocket streaming.
 - [BlockRunAI/blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) - Real-time data MCP with pay-per-call x402 payments; covers search, research, quotes, crypto, X, and Twitter.
+- [bargo-ai/bargo-free-api-packages](https://github.com/bargo-ai/bargo-free-api-packages) - Official Bargo MCP/API for U.S. congressional stock-trade disclosures, with REST and npm/Python clients.
 <a id="mcps-financemcp"></a>
 - [guangxiangdebizi/FinanceMCP](https://github.com/guangxiangdebizi/FinanceMCP) - Tushare + Binance MCP spanning A-shares / HK / US / funds / bonds / macro / stablecoins / crypto / financial news.
 - [chengzuopeng/stock-sdk](https://github.com/chengzuopeng/stock-sdk) - Zero-dependency TypeScript stock-data SDK with built-in MCP for A/H/US equities and funds via browser, Node.js, CLI, Claude Code, or Codex.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -196,6 +196,7 @@ MCPs 是让 Agent 通过 Model Context Protocol 调用外部工具的服务。�
 - [financial-datasets/mcp-server](https://github.com/financial-datasets/mcp-server) - Financial Datasets 厂商官方 MCP；美股 + 加密的基本面（三表 + 比率）+ 价格 + 新闻。
 - [6551Team/opennews-mcp](https://github.com/6551Team/opennews-mcp) - 84+ 信源聚合（Bloomberg / Reuters / FT / CoinDesk 等）+ AI 评定的影响打分 / 交易信号 + WebSocket 流。
 - [BlockRunAI/blockrun-mcp](https://github.com/BlockRunAI/blockrun-mcp) - 按调用计费的实时数据 MCP，使用 x402 微支付；覆盖搜索、研究、行情、加密、X / Twitter。
+- [bargo-ai/bargo-free-api-packages](https://github.com/bargo-ai/bargo-free-api-packages) - Bargo 官方 MCP/API，用于美国国会议员股票交易披露；提供 REST 和 npm/Python 客户端。
 <a id="mcps-financemcp"></a>
 - [guangxiangdebizi/FinanceMCP](https://github.com/guangxiangdebizi/FinanceMCP) - Tushare + Binance MCP 横跨 A 股 / HK / 美股 / 基金 / 债券 / 宏观 / 稳定币 / 加密 / 财经新闻。
 - [chengzuopeng/stock-sdk](https://github.com/chengzuopeng/stock-sdk) - 零依赖 TypeScript 股票数据 SDK + 内置 MCP server；覆盖 A / H / 美股和公募基金，支持 Browser / Node.js、CLI 与 Claude Code / Codex。


### PR DESCRIPTION
## Summary

Adds Bargo to the Market data / data providers MCP section in both English and Simplified Chinese READMEs.

## Submission metadata

- Canonical repo: https://github.com/bargo-ai/bargo-free-api-packages
- GitHub stars: 0
- Most recent repository activity: 2026-07-30

## Quality-bar check

- Public technical artifact: the repository contains official npm and Python clients plus the Bargo Congress MCP skill and links to public API documentation.
- LLM-driven: the hosted MCP exposes congressional trade disclosures as tools for agent workflows.
- Active: latest push was 2026-07-30.
- Documented and distinct: it focuses specifically on U.S. congressional stock-trade disclosures, which is distinct from the existing broad market-data and SEC filings entries.
- Credibility exception: although the project is new and has no stars yet, this is the official first-party Bargo MCP/API artifact; maintainers can decide whether that vendor exception is sufficient.

## Validation

- `npx --yes awesome-lint README.md`
- `npx --yes awesome-lint README.zh-CN.md`