### PR TITLE
Add Jawz — hosted MCP for macro regime + portfolio decision framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ MCPs are servers that let an agent call external tools through the Model Context
 - [guangxiangdebizi/TradingAgents-MCPmode](https://github.com/guangxiangdebizi/TradingAgents-MCPmode) - TradingAgents refactored as MCP tools for multi-agent equity research.
 - [QuantMLResearch/AI-Kline](https://github.com/QuantMLResearch/AI-Kline) - Stock-analysis tool combining classic technical analysis, AI prediction, and MCP access.
 - [wbsu2003/stock-scanner-mcp](https://github.com/wbsu2003/stock-scanner-mcp) - Stock scanner MCP for prices, scoring, technical reports, and AI summaries.
+- [Jawz](https://jawz.ai/docs/mcp) - Hosted MCP for macro-regime reads and portfolio decision framing; 22 read-only tools with anonymous access (no key), sources-and-freshness receipts on every response, and a data-health tool agents can use to audit staleness; deliberately produces no trade signals.
 
 > Also relevant: [dragon1086/prism-insight](#agents-prism-insight) is listed under Agents; this section mentions it because it has built-in MCP support for research.
 


### PR DESCRIPTION
Adds Jawz to **MCPs · Research tools / analysis**.

Jawz is a hosted MCP server (endpoint `https://jawz.ai/api/mcp`, streamable HTTP) for the market-state and decision-framing layer of a trading-agent stack:

- **22 read-only tools, anonymous by default** — macro regime (GREEN/YELLOW/RED + business-cycle quadrant), central-bank liquidity (Fed/ECB/BoJ/PBoC, constant-basis history), financial conditions, growth/inflation pillars, event calendar, and a published four-chapter decision framework agents can execute (`run_chapter` / `run_mode`). No API key for the entire read surface; rate limits are per daily-rotating IP hash.
- **Receipts on every response** — a sources-and-freshness block with per-input as-of dates, plus a `get_data_health` tool so an agent can audit whether the other tools are stale before trusting them.
- **Deliberately produces no trade signals** — it frames decisions (regime fit, drift, invalidation conditions) and refuses buy/sell instructions by design, which makes it composable with agents that do their own deciding.
- Headless OAuth 2.1 + PKCE with dynamic client registration is documented as a supported contract for the (optional) identity tools — 4 HTTP calls, no browser.

One honest note against the list's criteria: the server code is not open-source — the public artifacts are the live endpoint, the docs (https://jawz.ai/docs/mcp), the published framework (https://jawz.ai/loop), and a 5-minute recording of it running in ChatGPT (https://jawz.ai/demo). Currently in the ChatGPT plugin directory review queue and listed on mcpservers.org. If the list is repos-only, happy to withdraw — no hard feelings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
