### PR TITLE
docs: add selected 2026-W33 entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Agents are projects where an LLM is part of the actual research or trading decis
 - [vals-ai/finance-agent](https://github.com/vals-ai/finance-agent) - Finance-agent benchmark / task suite from vals-ai.
 <a id="agents-deepfund"></a>
 - [HKUSTDial/DeepFund](https://github.com/HKUSTDial/DeepFund) - Multi-agent fund-investment benchmark; LLM analysts evaluate stocks in a unified trading arena with leaderboard.
+- [Yijia-Xiao/FinanceHarness](https://github.com/Yijia-Xiao/FinanceHarness) - Autonomous financial-research harness with cited, point-in-time workflows and FinanceGym evaluation.
 
 <a id="agents-strategy-coding"></a>
 ### Strategy coding / self-improving agents
@@ -284,12 +285,14 @@ Skills are reusable instructions and workflows for Claude Code or other agent sy
 - [monarchjuno/tradingcodex](https://github.com/monarchjuno/tradingcodex) - Codex-native investment workflow team for research, portfolio work, and trading-oriented analysis.
 <a id="skills-alphaear"></a>
 - [RKiding/Awesome-finance-skills](https://github.com/RKiding/Awesome-finance-skills) - Alphaear Skill suite for news, stocks, sentiment, prediction, signal tracking, logic visualization, reporting, and search.
+- [komako-workshop/digital-oracle](https://github.com/komako-workshop/digital-oracle) - Market and macro research Skill using 13 public financial data sources for probability estimates and scenario analysis.
 
 > Also useful here: [HKUDS/Vibe-Trading](#agents-vibe-trading) and [ginlix-ai/LangAlpha](#agents-langalpha) both include bundled Skills. Their main entries stay under Agents because they are full agent workspaces, not just Skill packs.
 
 <a id="skills-crypto"></a>
 ### Crypto / DeFi / on-chain
 
+- [binance/binance-skills-hub](https://github.com/binance/binance-skills-hub) - Binance's official Skills hub with 18 packages for crypto research, trading, wallets, and DeFi.
 - [okx/onchainos-skills](https://github.com/okx/onchainos-skills) - OKX official Skills for OnchainOS, covering wallets, token discovery, quotes, DEX swaps, and transaction broadcasting.
 - [okx/agent-skills](https://github.com/okx/agent-skills) - OKX bilingual Skills repo with contribution, review, and security guidance; companion to onchainos-skills.
 - [GMGNAI/gmgn-skills](https://github.com/GMGNAI/gmgn-skills) - GMGN Agent Skills for querying tokens, wallets, and market data, and executing on-chain trades across Solana, BSC, and Base.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,6 +166,7 @@ Agents 是 LLM 参与市场研究或交易决策的项目，包括分析师团�
 - [vals-ai/finance-agent](https://github.com/vals-ai/finance-agent) - vals-ai 出品的金融 Agent benchmark / task 套件。
 <a id="agents-deepfund"></a>
 - [HKUSTDial/DeepFund](https://github.com/HKUSTDial/DeepFund) - 多 Agent 基金投资评测；LLM 分析师在统一交易竞技场内产生信号并通过排行榜对比。
+- [Yijia-Xiao/FinanceHarness](https://github.com/Yijia-Xiao/FinanceHarness) - 自治金融研究框架；用带引用、按时间点隔离的研究流程和 FinanceGym 评分评测金融 Agent。
 
 <a id="agents-strategy-coding"></a>
 ### Strategy coding / self-improving agents
@@ -281,12 +282,14 @@ Skills 是给 Claude Code 或其他 Agent 系统复用的说明和工作流。�
 - [monarchjuno/tradingcodex](https://github.com/monarchjuno/tradingcodex) - Codex-native 投资工作流团队；覆盖研究、组合和交易导向分析。
 <a id="skills-alphaear"></a>
 - [RKiding/Awesome-finance-skills](https://github.com/RKiding/Awesome-finance-skills) - Alphaear Skill suite；覆盖新闻、股票、情绪、预测、信号跟踪、逻辑可视化、报告和搜索。
+- [komako-workshop/digital-oracle](https://github.com/komako-workshop/digital-oracle) - 市场与宏观研究 Skill；汇总 13 个公开金融数据源，生成概率判断、信号对比和场景分析。
 
 > 这里也值得看：[HKUDS/Vibe-Trading](#agents-vibe-trading) 和 [ginlix-ai/LangAlpha](#agents-langalpha) 都内置 Skills。完整介绍放在 Agents，因为它们是完整的 Agent 工作台，不只是 Skill pack。
 
 <a id="skills-crypto"></a>
 ### Crypto / DeFi / on-chain
 
+- [binance/binance-skills-hub](https://github.com/binance/binance-skills-hub) - Binance 官方 Skills Hub；18 个 Skill，覆盖加密研究、交易、钱包和 DeFi。
 - [okx/onchainos-skills](https://github.com/okx/onchainos-skills) - OKX 官方 Skills，集成 OnchainOS API；覆盖钱包、代币发现、报价、DEX swap 和交易广播。
 - [okx/agent-skills](https://github.com/okx/agent-skills) - OKX 双语 EN / CN Skills 仓库；包含贡献、评审和安全说明；可和 onchainos-skills 一起看。
 - [GMGNAI/gmgn-skills](https://github.com/GMGNAI/gmgn-skills) - GMGN Agent Skills；查询 token、钱包和行情数据，并在 Solana / BSC / Base 上执行链上交易。


### PR DESCRIPTION
## 1. Repo URL · 仓库链接

- https://github.com/binance/binance-skills-hub
- https://github.com/komako-workshop/digital-oracle
- https://github.com/Yijia-Xiao/FinanceHarness

## 2. Pillar + sub-category · 放在哪个分类

- `binance/binance-skills-hub`: `Skills → Crypto / DeFi / on-chain`
- `komako-workshop/digital-oracle`: `Skills → Equity research`
- `Yijia-Xiao/FinanceHarness`: `Agents → Benchmarks & evaluations`

## 3. Entry bullet · 条目

```markdown
README.md:

- [binance/binance-skills-hub](https://github.com/binance/binance-skills-hub) - Binance's official Skills hub with 18 packages for crypto research, trading, wallets, and DeFi.
- [komako-workshop/digital-oracle](https://github.com/komako-workshop/digital-oracle) - Market and macro research Skill using 13 public financial data sources for probability estimates and scenario analysis.
- [Yijia-Xiao/FinanceHarness](https://github.com/Yijia-Xiao/FinanceHarness) - Autonomous financial-research harness with cited, point-in-time workflows and FinanceGym evaluation.

README.zh-CN.md:

- [binance/binance-skills-hub](https://github.com/binance/binance-skills-hub) - Binance 官方 Skills Hub；18 个 Skill，覆盖加密研究、交易、钱包和 DeFi。
- [komako-workshop/digital-oracle](https://github.com/komako-workshop/digital-oracle) - 市场与宏观研究 Skill；汇总 13 个公开金融数据源，生成概率判断、信号对比和场景分析。
- [Yijia-Xiao/FinanceHarness](https://github.com/Yijia-Xiao/FinanceHarness) - 自治金融研究框架；用带引用、按时间点隔离的研究流程和 FinanceGym 评分评测金融 Agent。
```

## 4. Quality-bar self-checklist · 条目自查

**GitHub stars at submission time**: `binance/binance-skills-hub` 952; `komako-workshop/digital-oracle` 771; `Yijia-Xiao/FinanceHarness` 72.

- [x] **Open source** — or has a public technical artifact (paper, architecture doc, reproducible demo).
- [x] **Demonstrably LLM-driven** — LLM reasoning is a primary decision component (not feature extractor / post-hoc explainer).
- [x] **Active in last 12 months** — or canonical / foundational reference.
- [x] **Clear scope + minimal documentation**.
- [x] **Distinct contribution** — not duplicative of existing entries.
- [x] **Public credibility signal** — normally >=100 GitHub stars for repo entries, or a documented maintainer-level exception.

No boxes are unchecked. Binance Skills Hub and FinanceHarness do not declare repository licenses; this list links them as public technical artifacts and does not claim their code is licensed for reuse. FinanceHarness is included as a maintainer-approved exception to the normal 100-star threshold because it is a new benchmark and paper companion.

## 5. Bilingual symmetric-edit · 中英文同步

- [x] I edited **both** `README.md` and `README.zh-CN.md` in this PR.
- [ ] I opened a tracked translation issue with 7-day SLA.

## 6. Awesome-lint advisory check · awesome-lint 辅助检查

- [x] I ran `npx --yes awesome-lint README.md`, or this PR does not change README structure.
- [x] I ran `npx --yes awesome-lint README.zh-CN.md`, or this PR does not change README.zh-CN.md structure.
- Notes / ignored findings: Both commands pass. `git diff --check` also passes.

## 7. Curation notes (optional) · 补充说明（可选）

These three projects were selected from the 2026-W33 weekly scan. Binance Skills Hub adds a first-party crypto Skills collection, digital-oracle adds public-source probability and scenario research, and FinanceHarness adds cited point-in-time workflows plus FinanceGym evaluation. This PR adds entries only and does not change the taxonomy.

By submitting this PR I agree that my contribution to the list's text is released under [CC0-1.0](../LICENSE).
