### PR TITLE
docs(skills): add quantwave skill entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Skills are reusable instructions and workflows for Claude Code or other agent sy
 <a id="skills-strategy-coding"></a>
 ### Strategy coding & backtesting
 
+- [lavs9/quantwave](https://github.com/lavs9/quantwave) - Polars-native TA and backtesting library with an agent skill for keeping research and live strategy code consistent.
 <a id="skills-vectorbt-backtesting"></a>
 - [marketcalls/vectorbt-backtesting-skills](https://github.com/marketcalls/vectorbt-backtesting-skills) - Skill for vectorbt backtesting with setup, backtest, optimization, quick stats, strategy comparison, and reusable strategy templates.
 - [MobiusQuant/OpenMobius-skill](https://github.com/MobiusQuant/OpenMobius-skill) - ICT / SMC trading-knowledge Skill for Claude Code, Codex, OpenClaw, and Hermes; includes curated knowledge cards, real-time market data, indicators, and chart generation.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -295,6 +295,7 @@ Skills 是给 Claude Code 或其他 Agent 系统复用的说明和工作流。�
 <a id="skills-strategy-coding"></a>
 ### Strategy coding & backtesting
 
+- [lavs9/quantwave](https://github.com/lavs9/quantwave) - Polars 原生 TA 与回测库；附带 agent skill，帮助保持研究代码和实盘策略代码一致。
 <a id="skills-vectorbt-backtesting"></a>
 - [marketcalls/vectorbt-backtesting-skills](https://github.com/marketcalls/vectorbt-backtesting-skills) - 面向 vectorbt 的回测 Skill；提供 setup、backtest、optimization、quick stats、strategy comparison 和可复用策略模板。
 - [MobiusQuant/OpenMobius-skill](https://github.com/MobiusQuant/OpenMobius-skill) - ICT / SMC 交易知识 Skill，面向 Claude Code、Codex、OpenClaw 和 Hermes；包含知识卡片、实时行情、技术指标和图表生成。


### PR DESCRIPTION
## Summary
- Add `lavs9/quantwave` under `Skills -> Strategy coding & backtesting` in both README files.
- Keep the English and Simplified Chinese README structures in sync.

Refs #43

## Submission metadata
- Repo: https://github.com/lavs9/quantwave
- Stars at submission time: 9
- Recent activity: 2026-08-13
- License: MIT
- Archived: no

## Quality-bar notes
- Open source: yes, MIT.
- LLM-driven angle: ships an agent skill for keeping research and live strategy code consistent.
- Active: yes, pushed on 2026-08-13.
- Documentation: project docs are available at https://lavs9.github.io/quantwave/.
- Distinct role: Polars-native TA/backtesting plus batch/streaming parity and an agent-skill surface.
- 100-star default floor: not met, so this PR is intentionally tied to #43 for maintainer judgment.

## Testing
- `git diff --check`
- `npx.cmd --yes awesome-lint README.md` *(advisory; local tool reported `awesome-github` repository detection error)*
- `npx.cmd --yes awesome-lint README.zh-CN.md` *(advisory; same repository detection error)*