### PR TITLE
docs(mcp): add livetennisapi/livetennisapi-mcp to market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ MCPs are servers that let an agent call external tools through the Model Context
 - [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) - Minimal yfinance MCP; a lightweight Yahoo Finance data option.
 - [OctagonAI/octagon-mcp-server](https://github.com/OctagonAI/octagon-mcp-server) - MCP for filings, earnings calls, financials, stock data, private-market deals, and web research.
 - [daniel3303/Equibles](https://github.com/daniel3303/Equibles) - Self-hosted finance data hub; syncs public SEC/FRED/Yahoo/FINRA/CFTC/CBOE data to PostgreSQL and serves it via MCP.
+- [livetennisapi/livetennisapi-mcp](https://github.com/livetennisapi/livetennisapi-mcp) - First-party tennis-data MCP; real-time tennis scores, market prices, and model win-probability for ATP/WTA/Challenger/ITF.
 
 <a id="mcps-brokerage"></a>
 ### Brokerage / exchange trading

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -210,6 +210,7 @@ MCPs 是让 Agent 通过 Model Context Protocol 调用外部工具的服务。�
 - [narumiruna/yfinance-mcp](https://github.com/narumiruna/yfinance-mcp) - 极简 yfinance MCP；获取 Yahoo Finance 数据的轻量选择。
 - [OctagonAI/octagon-mcp-server](https://github.com/OctagonAI/octagon-mcp-server) - 文件 / 财报会议 / 财务 / 股票数据 / 私募交易 / 网络研究；覆盖私募市场交易与 VC 数据。
 - [daniel3303/Equibles](https://github.com/daniel3303/Equibles) - 自部署金融数据中转站；把 SEC / FRED / Yahoo / FINRA / CFTC / CBOE 数据同步到 PostgreSQL，再通过 MCP 给 Agent 查询。
+- [livetennisapi/livetennisapi-mcp](https://github.com/livetennisapi/livetennisapi-mcp) - Live Tennis API 厂商官方网球数据 MCP；覆盖 ATP / WTA / Challenger / ITF 的实时比分、市场价格与模型胜率。
 
 <a id="mcps-brokerage"></a>
 ### Brokerage / exchange trading


### PR DESCRIPTION
Adds `livetennisapi/livetennisapi-mcp` under **MCPs -> Market data / data providers**, a first-party MCP server exposing real-time tennis scores, market prices, and model win-probability to LLM trading agents — the same data-provider shape as `financial-datasets/mcp-server` and `massive-com/mcp_massive`, filling a sports-data gap the section does not currently cover.

Disclosure: I run the Live Tennis API, so this is a vendor-authored entry — judge accordingly.

**Submission metadata**
- Repo: https://github.com/livetennisapi/livetennisapi-mcp
- Stars: 192 · Recent activity: 2026-08-16 · License: MIT
- Placed once, in its primary section; no anchor added (not cross-referenced); both `README.md` and `README.zh-CN.md` edited in the same PR, same order.

**Quality-bar self-check**
- [x] Open source (MIT), public artifact.
- [x] LLM-driven: an MCP server whose purpose is to give agents (Claude/Cursor/etc.) tool access to live tennis data.
- [x] Active (pushed 2026-08-16).
- [x] Clear scope + docs in the README.
- [x] Distinct: no tennis / sports market-data MCP currently in the section.
- [x] Credibility: 192 stars (clears the 100-star floor; also a first-party data-vendor MCP).