### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,4 +372,4 @@ The maintainer team reviews new entries and category changes.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LLMQuant/awesome-trading-agents&type=Date)](https://www.star-history.com/#LLMQuant/awesome-trading-agents&Date) 
+[![Star History Chart](https://star-history.dera.page/svg?repos=LLMQuant/awesome-trading-agents&type=Date)](https://star-history.dera.page/#LLMQuant/awesome-trading-agents&Date) 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -368,4 +368,4 @@ Skills 是给 Claude Code 或其他 Agent 系统复用的说明和工作流。�
 新条目和分类调整由 LLMQuant 维护团队评审。
 
 ## Star History
-  [![Star History Chart](https://api.star-history.com/svg?repos=LLMQuant/awesome-trading-agents&type=Date)](https://www.star-history.com/#LLMQuant/awesome-trading-agents&Date) 
+  [![Star History Chart](https://star-history.dera.page/svg?repos=LLMQuant/awesome-trading-agents&type=Date)](https://star-history.dera.page/#LLMQuant/awesome-trading-agents&Date) 


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying data source no longer works reliably. This switches it to the star-history.dera.page endpoint, which uses an alternative data source that requires no API token, so the chart renders correctly again.