### PR TITLE
docs(skills): add Adanos market sentiment skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Skills are reusable instructions and workflows for Claude Code or other agent sy
 - [xbtlin/ai-berkshire](https://github.com/xbtlin/ai-berkshire) - Value-investing research framework for Claude Code / Codex; combines four investor playbooks with multi-agent analysis.
 - [JoelLewis/finance_skills](https://github.com/JoelLewis/finance_skills) - Claude Code financial-services Skill pack; 84 skills across investment management, compliance, advisory workflows, trading operations, and portfolio reporting.
 - [quant-sentiment-ai/claude-equity-research](https://github.com/quant-sentiment-ai/claude-equity-research) - Claude Code research Skill for buy / sell / hold reports using fundamentals, technicals, option flow, insider activity, and sector context.
+- [adanos-software/adanos-market-sentiment-skill](https://github.com/adanos-software/adanos-market-sentiment-skill) - Official Agent Skill for stock and crypto research using Reddit, X, news, and Polymarket sentiment data.
 - [monarchjuno/tradingcodex](https://github.com/monarchjuno/tradingcodex) - Codex-native investment workflow team for research, portfolio work, and trading-oriented analysis.
 <a id="skills-alphaear"></a>
 - [RKiding/Awesome-finance-skills](https://github.com/RKiding/Awesome-finance-skills) - Alphaear Skill suite for news, stocks, sentiment, prediction, signal tracking, logic visualization, reporting, and search.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -278,6 +278,7 @@ Skills 是给 Claude Code 或其他 Agent 系统复用的说明和工作流。�
 - [xbtlin/ai-berkshire](https://github.com/xbtlin/ai-berkshire) - 面向 Claude Code / Codex 的价值投资研究框架；把四位投资大师方法论和 Multi-agent 分析结合起来。
 - [JoelLewis/finance_skills](https://github.com/JoelLewis/finance_skills) - 给 Claude Code 用的金融行业技能包；84 个小技能，帮它处理投资管理、合规检查、投顾日常、交易运营和持仓报告。
 - [quant-sentiment-ai/claude-equity-research](https://github.com/quant-sentiment-ai/claude-equity-research) - Claude Code 研究 Skill；用基本面、技术面、期权流、内部交易和行业背景生成买 / 卖 / 持有报告。
+- [adanos-software/adanos-market-sentiment-skill](https://github.com/adanos-software/adanos-market-sentiment-skill) - Adanos 官方 Agent Skill；为股票和加密研究提供 Reddit、X、新闻和 Polymarket 情绪数据。
 - [monarchjuno/tradingcodex](https://github.com/monarchjuno/tradingcodex) - Codex-native 投资工作流团队；覆盖研究、组合和交易导向分析。
 <a id="skills-alphaear"></a>
 - [RKiding/Awesome-finance-skills](https://github.com/RKiding/Awesome-finance-skills) - Alphaear Skill suite；覆盖新闻、股票、情绪、预测、信号跟踪、逻辑可视化、报告和搜索。


### PR DESCRIPTION
## 1. Repo URL · 仓库链接

https://github.com/adanos-software/adanos-market-sentiment-skill

## 2. Pillar + sub-category · 放在哪个分类

`Skills → Equity research`

## 3. Entry bullet · 条目

```markdown
- [adanos-software/adanos-market-sentiment-skill](https://github.com/adanos-software/adanos-market-sentiment-skill) - Official Agent Skill for stock and crypto research using Reddit, X, news, and Polymarket sentiment data.
```

```markdown
- [adanos-software/adanos-market-sentiment-skill](https://github.com/adanos-software/adanos-market-sentiment-skill) - Adanos 官方 Agent Skill；为股票和加密研究提供 Reddit、X、新闻和 Polymarket 情绪数据。
```

## 4. Quality-bar self-checklist · 条目自查

**GitHub stars at submission time**: 1

- [x] **Open source** — MIT-licensed public repository.
- [x] **Demonstrably LLM-driven** — the Agent Skill guides LLM agents through endpoint selection, plan-aware requests, and evidence handling for finance research.
- [x] **Active in last 12 months** — last updated 2026-08-09.
- [x] **Clear scope + minimal documentation**.
- [x] **Distinct contribution** — provides structured stock and crypto sentiment from Reddit, X, news, and Polymarket as an agent workflow.
- [x] **Public credibility signal** — submitted under the documented first-party artifact exception for data vendors.

The repository is below the normal 100-star floor, but it is the official, first-party Agent Skill maintained by the Adanos data provider. I maintain Adanos and am disclosing that affiliation here.

## 5. Bilingual symmetric-edit · 中英文同步

- [x] I edited **both** `README.md` and `README.zh-CN.md` in this PR.
- [ ] I opened a tracked translation issue with 7-day SLA.

## 6. Awesome-lint advisory check · awesome-lint 辅助检查

- [x] I ran `npx --yes awesome-lint README.md`.
- [x] I ran `npx --yes awesome-lint README.zh-CN.md`.
- Notes / ignored findings: Both checks pass without findings.

## 7. Curation notes (optional) · 补充说明（可选）

This is Adanos' official Agent Skill rather than a general API listing. It gives finance agents a repeatable, plan-aware workflow for retrieving and interpreting market-sentiment evidence without presenting it as a standalone trading signal.

By submitting this PR I agree that my contribution to the list's text is released under CC0-1.0.
